### PR TITLE
Update date generation to produce a valid RFC 3339 timestamp.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,8 +3,8 @@
 # Build security.txt app
 
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    DATE_NOW=$(date --rfc-3339='seconds')
-    DATE_EXP=$(date -d "+3 months" --rfc-3339='seconds')
+    DATE_NOW=$(date -u +"%Y-%m-%dT%H:%M:%Sz")
+    DATE_EXP=$(date -u -d "+3 months" +"%Y-%m-%dT%H:%M:%Sz")
 
     sed -i "s/DATE_NOW/${DATE_NOW}/g" ./security.txt
     sed -i "s/DATE_EXP/${DATE_EXP}/g" ./security.txt


### PR DESCRIPTION
The previous implementation used `--rfc-3339=seconds`, which outputs a format with a space separator and timezone offset (e.g. `2026-06-30 03:02:55+00:00`), which is not compliant with RFC 9116 requirements for the `Expires` field.

This change ensures the timestamp is generated in the correct format: `YYYY-MM-DDTHH:MM:SSz`

Validate: https://www.uriports.com/tools?method=securitytxt&domain=data.gov.uk